### PR TITLE
[FEAT] 공고 생성 페이지 API 연동 구현

### DIFF
--- a/src/features/jd/services/jobApi.ts
+++ b/src/features/jd/services/jobApi.ts
@@ -117,12 +117,12 @@ type JobCreateRequest = {
   location?: string | null;
   thumbnailUrl?: string | null;
   authorId: number;
-  requiredSkillIds?: number[];
-  preferredSkillIds?: number[];
+  requiredSkills?: string[];
+  preferredSkills?: string[];
 };
 
 export async function createJobPost(request: JobCreateRequest): Promise<string> {
-  const res = await fetch(`http://localhost:8080/api/v1/jd/create`, {
+  const res = await fetch(`http://localhost:8080/api/v1/jd`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/pages/JDCreatePage.tsx
+++ b/src/pages/JDCreatePage.tsx
@@ -1,13 +1,75 @@
-import JobPostForm from '../features/jd/components/form/JobPostForm';
-import type { JobPostFormValues } from '../features/jd/components/form/JobPostForm';
+// JDCreatePage.tsx
+import React, { useState } from 'react';
+import JobPostForm, { type JobPostFormValues } from '../features/jd/components/form/JobPostForm';
+import { createJobPost } from '../features/jd/services/jobApi';
 
-export default function JDCreatePage() {
-  const handleSubmit = (v: JobPostFormValues) => {
-    alert('제출 값: ' + JSON.stringify(v, null, 2));
+type JobCreateRequest = {
+  title: string;
+  department?: string | null;
+  workType?: string | null;
+  experience?: string | null;
+  education?: string | null;
+  salary?: string | null;
+  description: string | null;
+  deadline?: string | null;
+  benefits?: string | null;
+  location?: string | null;
+  thumbnailUrl?: string | null;
+  authorId: number;
+  requiredSkills?: string[];
+  preferredSkills?: string[];
+};
+
+const JDCreatePage: React.FC = () => {
+  const [submitting, setSubmitting] = useState(false);
+
+  // TODO: 나중에 로그인 붙으면 실제 로그인 유저의 ID로 교체
+  const authorId = 1;
+  const mapToJobCreateRequest = (values: JobPostFormValues): JobCreateRequest => {
+    const emptyToNull = (v?: string): string | null => (v && v.trim().length > 0 ? v : null);
+
+    return {
+      title: values.title,
+      department: emptyToNull(values.department),
+      workType: emptyToNull(values.workType),
+      experience: emptyToNull(values.experience),
+      education: emptyToNull(values.education),
+      salary: emptyToNull(values.salary),
+      description: emptyToNull(values.description),
+      deadline: values.deadline && values.deadline.length > 0 ? values.deadline : null,
+      benefits: emptyToNull(values.benefits),
+      location: emptyToNull(values.location),
+      thumbnailUrl: null,
+      authorId,
+      requiredSkills: values.requiredSkills ?? [],
+      preferredSkills: values.preferredSkills ?? [],
+    };
   };
+
+  const handleSubmit = async (values: JobPostFormValues) => {
+    try {
+      setSubmitting(true);
+
+      const request = mapToJobCreateRequest(values);
+      const id = await createJobPost(request);
+
+      alert(`공고가 등록되었습니다. ID: ${id}`);
+    } catch (error) {
+      console.error('createJobPost error:', error);
+      alert('공고 등록 중 오류가 발생했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-gray-50 p-4 sm:p-6">
-      <JobPostForm onSubmit={handleSubmit} />
+      <div className="mx-auto max-w-5xl">
+        <h1 className="mb-4 text-xl font-semibold text-gray-800">채용 공고 등록</h1>
+        <JobPostForm onSubmit={handleSubmit} submitting={submitting} />
+      </div>
     </main>
   );
-}
+};
+
+export default JDCreatePage;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #28 

## 📝 작업 내용

> 이전 공고 생성 페이지에서 API 연동 구현했습니다.

## 🖼️ 스크린샷 (선택)

> 시각적 변동은 없습니다.

## 💬 리뷰 요구사항 (선택)

> 지금 Skill 추가하는 기능에서 기존에 등록되어 있지 않은 스킬을 넣으면 아예 표시가 되지 않는 (DB에 저장되지 않는) 문제가 있는데 이를 프론트쪽에서 존재하는 스킬만 등록 가능하도록 구현할 예정입니다.
