### PR TITLE
[feat] 인터뷰 질문 페이지에서 면접 대상자의 정보 불러오는 API 구현

### DIFF
--- a/src/features/interview/components/manage/InterviewActions.tsx
+++ b/src/features/interview/components/manage/InterviewActions.tsx
@@ -10,6 +10,10 @@ interface InterviewActionsProps {
   avatar?: string;
   interviewId?: number;
   resumeId?: number;
+  date?: string;
+  time?: string;
+  interviewers?: string;
+  position?: string;
 }
 
 export default function InterviewActions({
@@ -18,6 +22,10 @@ export default function InterviewActions({
   avatar,
   interviewId,
   resumeId,
+  date,
+  time,
+  interviewers,
+  position,
 }: InterviewActionsProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const navigate = useNavigate();
@@ -33,7 +41,7 @@ export default function InterviewActions({
 
   const handleUpdateQuestionSet = () => {
     navigate(`/interview/${interviewId}/question-create`, {
-      state: { name, avatar, interviewId },
+      state: { name, avatar, interviewId, date, time, interviewers, position, resumeId },
     });
   };
 

--- a/src/features/interview/components/manage/InterviewCard.tsx
+++ b/src/features/interview/components/manage/InterviewCard.tsx
@@ -46,6 +46,10 @@ export default function InterviewCard({
         avatar={avatar}
         interviewId={id}
         resumeId={resumeId}
+        date={date}
+        time={time}
+        interviewers={interviewers}
+        position={position}
       />
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #90 

## 📝 작업 내용

> 인터뷰 질문 페이지에서 면접 대상자의 정보 불러오는 API 구현

## 🖼️ 스크린샷 (선택)

> 
<img width="336" height="314" alt="image" src="https://github.com/user-attachments/assets/fed9d6fb-44e6-4687-b824-823e9dec3834" />

<img width="387" height="208" alt="image" src="https://github.com/user-attachments/assets/d78b9f53-a093-4c30-b586-ad6925dba173" />
면접 Manage 페이지에서 정보를 받아오고 기술과 경험 관련 정보는 백엔드에서 API를 추가적으로 구현하여 연결하였습니다.
## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
