### PR TITLE
[fix] 한국시간으로 알림 및 면접 시간이 설정 안되는 버그 해결

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -9,7 +9,7 @@ type Notice = {
   id: number;
   title: string;
   message: string;
-  createdAt: string;
+  scheduledAt: string;
   interviewId?: number;
   readFlag?: boolean;
 };
@@ -43,7 +43,7 @@ const Header = () => {
       title: string;
       message: string;
       type: string;
-      createdAt: string;
+      scheduledAt: string;
       payload?: string;
       readFlag: boolean;
     }[]
@@ -65,7 +65,7 @@ const Header = () => {
           id: n.notificationId,
           title: n.title,
           message: n.message,
-          createdAt: n.createdAt,
+          scheduledAt: n.scheduledAt,
           interviewId: payload.interviewId,
           readFlag: n.readFlag,
         };
@@ -96,7 +96,7 @@ const Header = () => {
             id: data.notificationId,
             title: data.title,
             message: data.message,
-            createdAt: data.createdAt,
+            scheduledAt: data.scheduledAt,
             interviewId: payload.interviewId,
             readFlag: false,
           },
@@ -209,7 +209,6 @@ const Header = () => {
   const formatTime = (dateStr: string) => {
     if (!dateStr) return '';
     const d = new Date(dateStr);
-    d.setHours(d.getHours() + 9);
     return d.toLocaleString('ko-KR', {
       month: '2-digit',
       day: '2-digit',
@@ -290,7 +289,9 @@ const Header = () => {
                       <div className="flex-1">
                         <p className="text-sm font-medium text-black">{n.title}</p>
                         <p className="text-xs whitespace-pre-line text-black/60">{n.message}</p>
-                        <p className="mt-1 text-[10px] text-gray-400">{formatTime(n.createdAt)}</p>
+                        <p className="mt-1 text-[10px] text-gray-400">
+                          {formatTime(n.scheduledAt)}
+                        </p>
                       </div>
 
                       <button

--- a/src/features/interview/pages/InterviewCreatePage.tsx
+++ b/src/features/interview/pages/InterviewCreatePage.tsx
@@ -138,7 +138,7 @@ export default function InterviewCreatePage() {
     setIsSubmitting(true);
 
     // 선택된 날짜 + 시간 하나의 ISO로 병합
-    const scheduledAt = new Date(`${date}T${time}:00`).toISOString();
+    const scheduledAt = `${date}T${time}:00`;
 
     const body = {
       jdId: Number(jdId),

--- a/src/features/interview/pages/InterviewManagePage.tsx
+++ b/src/features/interview/pages/InterviewManagePage.tsx
@@ -76,15 +76,15 @@ export default function InterviewManagePage() {
       title: jd.title,
     })) ?? [];
 
-  const toKST = (dateStr: string) => {
-    const date = new Date(dateStr);
-    date.setHours(date.getHours() + 9);
-    return date;
-  };
+  // const toKST = (dateStr: string) => {
+  //   const date = new Date(dateStr);
+  //   date.setHours(date.getHours() + 9);
+  //   return date;
+  // };
 
   const interviews: InterviewCardData[] =
     interviewList?.data?.map((i) => {
-      const kstDate = toKST(i.scheduledAt);
+      const kstDate = new Date(i.scheduledAt);
       const pad = (n: number) => n.toString().padStart(2, '0');
 
       const year = kstDate.getFullYear();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #214 

## 📝 작업 내용

> 한국시간으로 알림 및 면접 시간이 설정 안되는 버그 해결
> 대시보드에 있는 면접 시간도 한국 시간으로 이제 설정 됩니다.

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
