### PR TITLE
[fix] 공고 수정 시 기존 이미지 삭제되는 오류 수정

### DIFF
--- a/src/features/jd/components/form/JobPostForm.tsx
+++ b/src/features/jd/components/form/JobPostForm.tsx
@@ -82,10 +82,10 @@ export default function JobPostForm({
         </div>
         <div className="sm:col-span-2">
           <Field label="썸네일 이미지 (선택)">
-            {defaultValues?.originalThumbnailUrl && !values.thumbnailFile && (
+            {values?.originalThumbnailUrl && !values.thumbnailFile && (
               <div className="mb-2">
                 <img
-                  src={defaultValues.originalThumbnailUrl}
+                  src={values.originalThumbnailUrl}
                   alt="Current Thumbnail"
                   className="h-24 w-24 rounded-md object-cover"
                 />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #216 

## 📝 작업 내용

> 공고 수정 시 기존 이미지가 사라지는 오류 수정

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
