### PR TITLE
[fix] 지원자 조회 및 추천 조회 페이지에서 이력서 프로필 안뜨는 오류 관련 수정

### DIFF
--- a/src/features/match/components/MatchCard.tsx
+++ b/src/features/match/components/MatchCard.tsx
@@ -71,9 +71,12 @@ export default function MatchCard({ resume, matchRate, tab, onView, onInvite }: 
       <div className="flex w-full items-start gap-4 pr-[160px]">
         {/* 프로필 이미지 */}
         <img
-          src={resume.profileImage || '/default-profile.png'}
+          src={resume.profileImage || '/images/default-profile.jpg'}
           alt={resume.name}
           className="h-24 w-24 rounded-full object-cover"
+          onError={(e) => {
+            e.currentTarget.src = '/images/default-profile.jpg';
+          }}
         />
 
         <div className="flex w-full flex-col justify-between">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> X 

## 📝 작업 내용

- 지원자 카드에서 프로필 이미지 렌더링 로직 수정
- 백엔드에서 전달되는 presigned URL 기반 이미지 표시
- 이미지 누락/만료/오류 시 기본 프로필 이미지로 fallback 처리

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
