### PR TITLE
[feat] 사이드바 선택된 페이지 항목 강조 표시

### DIFF
--- a/src/shared/components/SidebarDrawer.tsx
+++ b/src/shared/components/SidebarDrawer.tsx
@@ -184,7 +184,6 @@ export default function SidebarDrawer({ open, onClose }: Props) {
           </NavLink>
         </nav>
 
-        {/* 하단 사용자 카드 */}
         <div className="absolute right-0 bottom-0 left-0 px-3 py-3">
           <div
             role="button"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #255 

## 📝 작업 내용

> 사이드바에서 선택된 페이지 항목에 강조 표시

## 🖼️ 스크린샷 (선택)

<img width="557" height="375" alt="sidebar_select" src="https://github.com/user-attachments/assets/4fd0d549-5fb8-423c-9f20-f9af381312ec" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
